### PR TITLE
Added storage of update method to enable automatic client installation

### DIFF
--- a/client/facileManager/fmDNS/functions.php
+++ b/client/facileManager/fmDNS/functions.php
@@ -78,6 +78,11 @@ function installFMModule($module_name, $proto, $compress, $data, $server_locatio
 	
 	echo fM("\n  --> Tests complete.  Continuing installation.\n\n");
 	
+	/* Set update method if specified in config.inc.php */
+	if(defined("FMDNS_UPDATE_METHOD")) {
+		$update_method = FMDNS_UPDATE_METHOD;
+	}
+	
 	/** Update via cron or http/s? */
 	$update_choices = array('c', 's', 'h');
 	while (!isset($update_method)) {
@@ -93,6 +98,8 @@ function installFMModule($module_name, $proto, $compress, $data, $server_locatio
 
 	$raw_data = getPostData(str_replace('genserial', 'addserial', $url), $data);
 	$raw_data = $data['compress'] ? @unserialize(gzuncompress($raw_data)) : @unserialize($raw_data);
+	
+	$data['config'][] = array('FMDNS_UPDATE_METHOD', 'fmDNS update method', $update_method);
 	
 	return $data;
 }


### PR DESCRIPTION
I change fmDNS a little to also store the update method. This enables scenarios where the configuration is not created by the client installation but rather by a script or automation process. With this change `php dns.php install` does not block interactively and can be automated.
