### PR TITLE
proposed patch for client.php sudoers installer

### DIFF
--- a/client/facileManager/functions.php
+++ b/client/facileManager/functions.php
@@ -866,7 +866,7 @@ function processUpdateMethod($module_name, $update_method = null, $data, $url) {
 			}
 			
 			/** Add an entry to sudoers */
-			$sudoers_line = "$user\tALL=(root)\tNOPASSWD: " . findProgram('php') . ' ' . $argv[0] . ' *';
+			$sudoers_line = "$user\tALL=(root)\tNOPASSWD: " . findProgram('php') . ' ' . dirname(__FILE__) . ' *';
 			addSudoersConfig($module_name, $sudoers_line, $user);
 
 			return 'ssh';


### PR DESCRIPTION
Changing $argv[0] to dirname(__FILE__) would prevent future sudoers errors not referencing the full path to the client.php file, see issue #372