### PR TITLE
Issue #399 Add option 'request_fulluri' for proxy server

### DIFF
--- a/server/fm-modules/fmDNS/classes/class_buildconf.php
+++ b/server/fm-modules/fmDNS/classes/class_buildconf.php
@@ -1459,6 +1459,7 @@ HTML;
 		if (getOption('proxy_enable')) {
 			$default_opts = array(
 				'http' => array(
+					'request_fulluri' => true,
 					'method' => 'GET',
 					'proxy' => 'tcp://' . getOption('proxy_host') . ':' . getOption('proxy_port')
 				)


### PR DESCRIPTION
Sometimes the client (fmDNS) sends a incomplete request (GET /domain/named.root) via a proxy server (squid). Option 'request_fulluri' forces the client (fmDNS) to send a full request through a proxy server (GET http://www.internic.net/domain/named.root).