### PR TITLE
version bump to 3.2

### DIFF
--- a/client/facileManager/fmDNS/client.php
+++ b/client/facileManager/fmDNS/client.php
@@ -29,7 +29,7 @@
  */
 
 /** Client version */
-$data['server_client_version'] = '3.1';
+$data['server_client_version'] = '3.2';
 
 error_reporting(0);
 


### PR DESCRIPTION
Updated everything to 3.2 but Manager still reported that DNS servers needed an update. From the DNS cli, attempted to run "sudo php /usr/local/facileManager/fmDNS/client.php upgrade" but all results were 3.1. Clean install, same result. Discovered old static version number.