### PR TITLE
Changed parameter in SSH connection

### DIFF
--- a/server/fm-modules/facileManager/functions.php
+++ b/server/fm-modules/facileManager/functions.php
@@ -3423,7 +3423,7 @@ function runRemoteCommand($host_array, $command, $format = 'silent', $port = 22,
 		}
 
 		/** Test SSH authentication */
-		exec(findProgram('ssh') . " -t -i $temp_ssh_key -o 'StrictHostKeyChecking no' -p $port -l $ssh_user $host 'ls /usr/local/$fm_name/{$_SESSION['module']}/client.php'", $output, $rc);
+		exec(findProgram('ssh') . " -T -i $temp_ssh_key -o 'StrictHostKeyChecking no' -p $port -l $ssh_user $host 'ls /usr/local/$fm_name/{$_SESSION['module']}/client.php'", $output, $rc);
 		if ($rc) {
 			/** Something went wrong */
 			if ($rc == 255 || $client_check == 'include') {
@@ -3441,7 +3441,7 @@ function runRemoteCommand($host_array, $command, $format = 'silent', $port = 22,
 		}
 		unset($output);
 
-		exec(findProgram('ssh') . " -t -i $temp_ssh_key -o 'StrictHostKeyChecking no' -p $port -l $ssh_user $host \"$command\"", $output, $rc);
+		exec(findProgram('ssh') . " -T -i $temp_ssh_key -o 'StrictHostKeyChecking no' -p $port -l $ssh_user $host \"$command\"", $output, $rc);
 	
 		if ($rc) {
 			$failures = true;


### PR DESCRIPTION
Changed parameter in SSH connection to avoid "Pseudo-terminal will not be allocated because stdin is not a terminal" warning

This thread explains the issue better:
https://stackoverflow.com/questions/7114990/pseudo-terminal-will-not-be-allocated-because-stdin-is-not-a-terminal
