### PR TITLE
Update class_logins.php

### DIFF
--- a/server/fm-modules/facileManager/classes/class_logins.php
+++ b/server/fm-modules/facileManager/classes/class_logins.php
@@ -257,8 +257,9 @@ class fm_login {
 		$fm_db_version = getOption('fm_db_version');
 		$auth_method = ($fm_db_version >= 18) ? getOption('auth_method') : true;
 		if ($auth_method) {
-			/** Default Super Admin? */
-			$result = $fmdb->query("SELECT * FROM `fm_users` WHERE `user_auth_type`=1 ORDER BY user_id ASC LIMIT 1");
+			/** Default Super Admin? ... Will Use Builtin Auth when Default Auth Method is LDAP but user is defined with 'facileManager/Builtin' */
+			//$result = $fmdb->query("SELECT * FROM `fm_users` WHERE `user_auth_type`=1 ORDER BY user_id ASC LIMIT 1");
+			$result = $fmdb->query("SELECT * FROM `fm_users` WHERE `user_login` = '$user_login' and `user_auth_type`=1 and `user_status`='active'");
 			if ($fmdb->last_result[0]->user_login == $user_login) {
 				$auth_method = 1;
 			}


### PR DESCRIPTION
When in "General Settings"  "Authentication Method" is set to LDAP ... 
And then when you create a new user and try to set Authentication Method to "Builtin Auth..." for this particular User ... this user setting has no meaning since the aut_method = 1 was only looking for basically  one entry in the `fm_users` table typically admin)`
...
with this change (probably the code can be different from my proposal) .. you can have default ldap auth ... but still have users that will authenticate with local pass.

In general my goal is to have default ldap login but still provide login to local created users that will never be in a ldap environment.

tks
dS