### PR TITLE
Fix "Require Group Membership" not working...

### DIFF
--- a/server/fm-modules/facileManager/classes/class_logins.php
+++ b/server/fm-modules/facileManager/classes/class_logins.php
@@ -572,7 +572,7 @@ This link expires in %s.',
 						$ldap_group_response = $this->checkGroupMembership($ldap_connect, $this->getDN($ldap_connect, $username, $ldap_dn), $ldap_group_dn, $ldap_group_attribute);
 					} else {
 						/** Process LDAP group membership */
-						$ldap_group_response = @ldap_compare($ldap_connect, $ldap_group_dn, $ldap_group_attribute, $username);
+						$ldap_group_response = @ldap_compare($ldap_connect, $ldap_group_dn, $ldap_group_attribute, $ldap_dn);
 					}
 					
 					if ($ldap_group_response !== true) {


### PR DESCRIPTION
Maybe it's only the case of FreeIPA (389ds), but... Is there any LDAP implementation not putting in the "member" attribute (or whatever it be) a full distinguished name?