### PR TITLE
Fix errors in SQL scripts for fmDNS update to 6.0.0

### DIFF
--- a/server/fm-modules/fmDNS/upgrade.php
+++ b/server/fm-modules/fmDNS/upgrade.php
@@ -2471,7 +2471,7 @@ function upgradefmDNS_600($__FM_CONFIG, $running_version) {
 	$success = version_compare($running_version, '5.3.0', '<') ? upgradefmDNS_530($__FM_CONFIG, $running_version) : true;
 	if (!$success) return false;
 	
-	$queries[] = "UPDATE `fm_{$__FM_CONFIG['fmDNS']['prefix']}functions` CHANGE `def_option_type` `def_option_type` ENUM('global','ratelimit','rrset','rpz','http','tls','dnssec-policy')  NOT NULL DEFAULT 'global'";
+	$queries[] = "ALTER TABLE `fm_{$__FM_CONFIG['fmDNS']['prefix']}functions` CHANGE `def_option_type` `def_option_type` ENUM('global','ratelimit','rrset','rpz','http','tls','dnssec-policy')  NOT NULL DEFAULT 'global'";
 	$queries[] = <<<INSERTSQL
 INSERT IGNORE INTO  `fm_{$__FM_CONFIG['fmDNS']['prefix']}functions` (
 	`def_function` ,
@@ -2553,7 +2553,7 @@ INSERTSQL;
 	$queries[] = "UPDATE `fm_{$__FM_CONFIG['fmDNS']['prefix']}functions` SET `def_clause_support` = 'ZV' WHERE `def_option` = 'max-records'";
 	$queries[] = "UPDATE `fm_{$__FM_CONFIG['fmDNS']['prefix']}functions` SET `def_clause_support` = 'OV' WHERE `def_option_type` = 'ratelimit'";
 
-	$queries[] = "UPDATE `fm_{$__FM_CONFIG['fmDNS']['prefix']}config` SET `cfg_status`='deleted' WHERE `cfg_type`='ratelimit' AND `domaain_id`!=0";
+	$queries[] = "UPDATE `fm_{$__FM_CONFIG['fmDNS']['prefix']}config` SET `cfg_status`='deleted' WHERE `cfg_type`='ratelimit' AND `domain_id`!=0";
 	$queries[] = "ALTER TABLE `fm_{$__FM_CONFIG['fmDNS']['prefix']}masters` ADD `master_tls_id` INT NOT NULL DEFAULT '0' AFTER `master_key_id`";
 	$queries[] = "ALTER TABLE `fm_{$__FM_CONFIG['fmDNS']['prefix']}domains` CHANGE `domain_type` `domain_type` ENUM('primary','secondary','master','slave','forward','stub') NOT NULL DEFAULT 'primary'";
 	$queries[] = "UPDATE `fm_{$__FM_CONFIG['fmDNS']['prefix']}domains` SET `domain_type`='primary' WHERE `domain_type`='master'";
@@ -2568,7 +2568,7 @@ INSERTSQL;
 	  `file_id` INT(11) NOT NULL AUTO_INCREMENT PRIMARY KEY ,
 	  `account_id` int(11) NOT NULL DEFAULT '1',
 	  `server_serial_no` varchar(255) NOT NULL DEFAULT '0',
-	  `file_location` ENUM('\$ROOT') NOT NULL DEFAULT '\$ROOT'
+	  `file_location` ENUM('\$ROOT') NOT NULL DEFAULT '\$ROOT',
 	  `file_name` VARCHAR(255) NOT NULL ,
 	  `file_contents` text,
 	  `file_comment` text,

--- a/server/fm-modules/fmDNS/upgrade.php
+++ b/server/fm-modules/fmDNS/upgrade.php
@@ -2471,7 +2471,7 @@ function upgradefmDNS_600($__FM_CONFIG, $running_version) {
 	$success = version_compare($running_version, '5.3.0', '<') ? upgradefmDNS_530($__FM_CONFIG, $running_version) : true;
 	if (!$success) return false;
 	
-	$queries[] = "ALTER TABLE `fm_{$__FM_CONFIG['fmDNS']['prefix']}functions` CHANGE `def_option_type` `def_option_type` ENUM('global','ratelimit','rrset','rpz','http','tls','dnssec-policy')  NOT NULL DEFAULT 'global'";
+	$queries[] = "ALTER TABLE `fm_{$__FM_CONFIG['fmDNS']['prefix']}functions` CHANGE  `def_function` `def_function` ENUM('options', 'logging', 'key', 'view', 'http', 'tls', 'dnssec-policy')  NOT NULL DEFAULT 'global'";
 	$queries[] = <<<INSERTSQL
 INSERT IGNORE INTO  `fm_{$__FM_CONFIG['fmDNS']['prefix']}functions` (
 	`def_function` ,


### PR DESCRIPTION
Subj.
There is also an issue with new options insert even after alter table, new options are inserted with empty first column with warning "Error Code: 1265. Data truncated for column 'def_function' at row 1"