### PR TITLE
Update class_buildconf.php

### DIFF
--- a/server/fm-modules/fmDNS/classes/class_buildconf.php
+++ b/server/fm-modules/fmDNS/classes/class_buildconf.php
@@ -2207,6 +2207,7 @@ HTML;
 					}
 					
 					if (in_array($server_id, $group_slaves)) {
+						$tmp_key_id = "";
 						if ($domain_key_id) {
 							$tmp_key_id = $domain_key_id;
 						}


### PR DESCRIPTION
fM Version : 4.7.0 ...&&... 5.0.0b2
fmDNS Version : 6.2.0 ...&&... 7.0.0b2

when updating secondary ... an error output is displayed . ...
"Notice: Undefined variable: tmp_key_id in /var/www/html/dnsadmin/fm-modules/fmDNS/classes/class_buildconf.php on line 2242 "
...

Probably related with #512 ... key for transfer zone in views.

![image](https://github.com/user-attachments/assets/d64dcc89-0b4a-49fd-b06d-bf3a825f7b23)

Aldo optional the config built was expecting this variable.
(the config itself on disk seems to be written ok)


example:
![image](https://github.com/user-attachments/assets/3f660fad-4e4a-420e-877c-bb5dedb68ca7)

![image](https://github.com/user-attachments/assets/79b32f97-2d2e-43ca-878c-3f936b5e2de3)


with this, the error goes away:
![image](https://github.com/user-attachments/assets/e55daa3e-316c-434b-ac5f-0582996a4226)

![image](https://github.com/user-attachments/assets/8876eb81-6b43-4d5f-8a86-009e646dca39)



Regards
david











