### PR TITLE
Add API autoupdate parameter

### DIFF
--- a/client/facileManager/fmDNS/client.php
+++ b/client/facileManager/fmDNS/client.php
@@ -46,7 +46,7 @@ if (!$api_call) {
 } else {
 	$api_supported_rr = array('A', 'AAAA', 'CNAME', 'DNAME', 'MX', 'NS', 'PTR', 'TXT');
 	$api_params = array(
-		'common' => array('action', 'id', 'type', 'name', 'value', 'ttl', 'comment', 'status'),
+		'common' => array('action', 'id', 'type', 'name', 'value', 'ttl', 'comment', 'status', 'autoupdate'),
 		'CNAME'  => array('append'),
 		'DNAME'  => array('append'),
 		'MX'  => array('priority', 'append'),
@@ -82,7 +82,7 @@ for ($i=0; $i < count($argv); $i++) {
 		foreach (array_unique(call_user_func_array('array_merge', array_values($api_params))) as $param) {
 			if (strncmp(strtolower($argv[$i]), $param . '=', strlen($param) + 1) == 0) {
 				$prefix = ($param == 'id') ? 'domain_' : 'record_';
-				if ($param == 'action') $prefix = null;
+				if (in_array($param, array('action', 'autoupdate'))) $prefix = null;
 				$data['api'][$prefix . $param] = substr($argv[$i], strlen($param) + 1);
 
 				validateAPIParam($param, $data['api'][$prefix . $param]);

--- a/client/facileManager/fmDNS/functions.php
+++ b/client/facileManager/fmDNS/functions.php
@@ -609,7 +609,8 @@ function validateAPIParam($param, $value) {
 	$api_quick_validation = array(
 		'append' => array('yes', 'no'),
 		'action' => array('add', 'update', 'delete'),
-		'status' => array('active', 'disabled')
+		'status' => array('active', 'disabled'),
+		'autoupdate' => array('yes', 'no')
 	);
 
 	if (array_key_exists($param, $api_quick_validation)) {

--- a/server/fm-modules/fmDNS/pages/api.inc.php
+++ b/server/fm-modules/fmDNS/pages/api.inc.php
@@ -31,7 +31,7 @@ if (isset($_POST['domain_id'])) {
     $domain_id = intval($_POST['domain_id']);
 }
 
-$exclude = array('action', 'domain_id');
+$exclude = array('action', 'domain_id', 'autoupdate');
 
 foreach ($_POST['api'] as $key => $val) {
     if (!in_array($key, $exclude)) $record_data[$key] = sanitize($val);
@@ -131,6 +131,9 @@ if ($error) {
     $data = throwAPIError($code);
     // $data .= $fmdb->last_error;
 } elseif ($data === true) {
+    if ($_POST['api']['autoupdate'] == "yes") {
+        reloadZoneSQL($domain_id, 'no', 'single');
+    }
     $data = _('Success') . "\n";
 }
 

--- a/server/fm-modules/fmDNS/pages/api.inc.php
+++ b/server/fm-modules/fmDNS/pages/api.inc.php
@@ -133,6 +133,7 @@ if ($error) {
 } elseif ($data === true) {
     if ($_POST['api']['autoupdate'] == "yes") {
         reloadZoneSQL($domain_id, 'no', 'single');
+        $fm_dns_zones->buildZoneConfig($domain_id);
     }
     $data = _('Success') . "\n";
 }


### PR DESCRIPTION
As stated in https://github.com/WillyXJ/facileManager/discussions/589: "the API is not able to issue zone updates on other clients nor does it reset zone reload flags in the database as those get updates through the GUI when all associated servers get successfully updated".
These few changes allow zone updates via an optional autoupdate parameter when calling client.php for API connection.

example:
`php client.php setHost id=22 action=add name=_acme-challenge value="5eaqdCurfBqU94VM837tdM1GBRzbSgVKPJ-ke0rE6QY" type=TXT ttl=300 autoupdate=yes`

I have quite the same interest in ACME updates as @internethering: I'm developing a DNS Challenge Plugin for Proxmox and I need an automated zone update.
I will open a new discussion with my Proxmox solution as soon as I'm able to test it successfully (together with a pull request for the new fm dnsapi at https://github.com/acmesh-official/acme.sh).
