### PR TITLE
Fixed long data entry and idle sessions

### DIFF
--- a/server/fm-modules/facileManager/change.log
+++ b/server/fm-modules/facileManager/change.log
@@ -1,3 +1,7 @@
+5.1.2 (2025-02-??)
+==================
+* Server - [bug] Fixed logging of long messages.
+
 5.1.1 (2025-02-03)
 ==================
 * Server - [bug] Fixed CSS of disabled buttons.

--- a/server/fm-modules/facileManager/change.log
+++ b/server/fm-modules/facileManager/change.log
@@ -1,6 +1,7 @@
 5.1.2 (2025-02-??)
 ==================
 * Server - [bug] Fixed logging of long messages.
+* Server - [bug] Fixed automatic logout when the session expires.
 
 5.1.1 (2025-02-03)
 ==================

--- a/server/fm-modules/facileManager/install.php
+++ b/server/fm-modules/facileManager/install.php
@@ -244,7 +244,7 @@ CREATE TABLE IF NOT EXISTS `$database`.`fm_logs` (
   `account_id` int(11) NOT NULL DEFAULT '1',
   `log_module` varchar(255) NOT NULL,
   `log_timestamp` int(10) NOT NULL DEFAULT '0',
-  `log_data` text NOT NULL,
+  `log_data` mediumtext NOT NULL,
   PRIMARY KEY (`log_id`)
 ) ENGINE=INNODB DEFAULT CHARSET=utf8 ;
 TABLESQL;

--- a/server/fm-modules/facileManager/js/facileManager.php
+++ b/server/fm-modules/facileManager/js/facileManager.php
@@ -56,6 +56,10 @@ if (isset($__FM_CONFIG)) {
 				timeout: 2000,
 				data: form_data,
 				success: function(response) {
+					if (response.indexOf("force_logout") >= 0 || response.indexOf("login_form") >= 0) {
+						doLogout();
+						return false;
+					}
 					if (response == 0 || ! $.isNumeric(response)) {
 						$(".process_all_updates").parent().fadeOut(400);
 					} else {

--- a/server/fm-modules/facileManager/upgrade.php
+++ b/server/fm-modules/facileManager/upgrade.php
@@ -947,6 +947,34 @@ function fmUpgrade_510($database) {
 }
 
 
+/** fM v5.1.2 **/
+function fmUpgrade_512($database) {
+	global $fmdb;
+	
+	$success = true;
+	
+	/** Prereq */
+	$success = ($GLOBALS['running_db_version'] < 56) ? fmUpgrade_510($database) : true;
+	
+	$queries = array();
+	if ($success) {
+		$queries[] = "ALTER TABLE `fm_logs` MODIFY COLUMN `log_data` MEDIUMTEXT";
+		
+		/** Create table schema */
+		if (count($queries) && $queries[0]) {
+			foreach ($queries as $schema) {
+				$fmdb->query($schema);
+				if (!$fmdb->result || $fmdb->sql_errors) return false;
+			}
+		}
+	}
+
+	upgradeConfig('fm_db_version', 57, false);
+	
+	return $success;
+}
+
+
 /**
  * Updates the database with the db version number.
  *

--- a/server/fm-modules/fmDNS/change.log
+++ b/server/fm-modules/fmDNS/change.log
@@ -1,5 +1,9 @@
 7.0.4 (2025-02-03)
 ==================
+* Server - [bug] Fixed cases where long custom resource record data and file contents would not save.
+
+7.0.4 (2025-02-03)
+==================
 * Server - [bug] Fixed CSS of the records "Validate All" button.
 
 7.0.3 (2025-02-02)

--- a/server/fm-modules/fmDNS/install.php
+++ b/server/fm-modules/fmDNS/install.php
@@ -133,7 +133,7 @@ CREATE TABLE IF NOT EXISTS `$database`.`fm_{$__FM_CONFIG[$module]['prefix']}file
   `server_serial_no` varchar(255) NOT NULL DEFAULT '0',
   `file_location` ENUM('\$ROOT') NOT NULL DEFAULT '\$ROOT',
   `file_name` VARCHAR(255) NOT NULL,
-  `file_contents` text,
+  `file_contents` mediumtext,
   `file_comment` text,
   `file_status` ENUM( 'active', 'disabled', 'deleted') NOT NULL DEFAULT 'active'
 ) ENGINE = INNODB DEFAULT CHARSET=utf8;
@@ -204,7 +204,7 @@ CREATE TABLE IF NOT EXISTS `$database`.`fm_{$__FM_CONFIG[$module]['prefix']}reco
   `record_ptr_id` int(11) NOT NULL DEFAULT '0',
   `record_timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `record_name` varchar(255) DEFAULT '@',
-  `record_value` text,
+  `record_value` mediumtext,
   `record_ttl` varchar(50) NOT NULL DEFAULT '',
   `record_class` enum('IN','CH','HS') NOT NULL DEFAULT 'IN',
   `record_type` enum('A','AAAA','CAA','CERT','CNAME','DHCID','DLV','DNAME','DNSKEY','DS','HINFO','KEY','KX','MX','NAPTR','NS','OPENPGPKEY','PTR','RP','SMIMEA','SSHFP','SRV','TLSA','TXT','URI','URL','CUSTOM') NOT NULL DEFAULT 'A',

--- a/server/fm-modules/fmDNS/upgrade.php
+++ b/server/fm-modules/fmDNS/upgrade.php
@@ -2892,3 +2892,25 @@ function upgradefmDNS_702($__FM_CONFIG, $running_version) {
 	
 	return true;
 }
+
+/** 7.0.5 */
+function upgradefmDNS_705($__FM_CONFIG, $running_version) {
+	global $fmdb;
+	
+	$success = version_compare($running_version, '7.0.2', '<') ? upgradefmDNS_702($__FM_CONFIG, $running_version) : true;
+	if (!$success) return false;
+	
+	$queries[] = "ALTER TABLE `fm_{$__FM_CONFIG['fmDNS']['prefix']}records` MODIFY COLUMN record_value MEDIUMTEXT";
+	$queries[] = "ALTER TABLE `fm_{$__FM_CONFIG['fmDNS']['prefix']}files` MODIFY COLUMN file_contents MEDIUMTEXT";
+
+	/** Run queries */
+	if (isset($queries) && count($queries) && $queries[0]) {
+		foreach ($queries as $schema) {
+			$fmdb->query($schema);
+		}
+	}
+
+	setOption('version', '7.0.5', 'auto', false, 0, 'fmDNS');
+	
+	return true;
+}


### PR DESCRIPTION
This PR attempts to address:

- CUSTOM RR data would not save if the contents exceeds 65,535 characters
- File contents data would not save if the contents exceeds 65,535 characters
- Log data would not save if the contents exceeds 65,535 characters

The fix is simply changing the database column types from TEXT to MEDIUMTEXT (16,777,215 characters).  There probably is no reason to go to LONGTEXT.

In addition (sorry for grouping a second change in the same PR), this PR will return the user to the login screen on idle pages when the session expires.