### PR TITLE
Update fmFirewall client function name

### DIFF
--- a/client/facileManager/fmFirewall/client.php
+++ b/client/facileManager/fmFirewall/client.php
@@ -45,7 +45,7 @@ if (file_exists($fm_client_functions)) {
 }
 
 /** Check if running supported version */
-$data['server_version'] = detectFWVersion();
+$data['server_version'] = detectAppVersion();
 
 /** Build the configs provided by $url */
 $retval = buildConf($url, $data);


### PR DESCRIPTION
This PR fixes #676 by changing the referenced function name in fmFirewall/client.php to the new function name.