### PR TITLE
Tooltip inconsistency fixes

### DIFF
--- a/server/fm-modules/fmDHCP/change.log
+++ b/server/fm-modules/fmDHCP/change.log
@@ -1,3 +1,7 @@
+0.10.? (2025-??-??)
+==================
+* Server - [bug] Fixed inconsistent tooltips for "Configure Additional Options."
+
 0.10.1 (2025-04-21)
 ===================
 * Server - [bug] Fixed PHP errors. (Issue #674)

--- a/server/fm-modules/fmDHCP/classes/class_groups.php
+++ b/server/fm-modules/fmDHCP/classes/class_groups.php
@@ -82,7 +82,7 @@ class fm_dhcp_groups extends fm_dhcp_objects {
 			$edit_status = '<td class="column-actions">' . $edit_status . '</td>';
 			$checkbox = '<input type="checkbox" name="bulk_list[]" value="' . $row->config_id .'" />';
 		}
-		$icons[] = sprintf('<a href="config-options.php?item_id=%d" class="mini-icon"><i class="mini-icon fa fa-sliders" title="%s" aria-hidden="true"></i></a>', $row->config_id, __('Configure Additional Options'));
+		$icons[] = sprintf('<a href="config-options.php?item_id=%d" class="tooltip-bottom mini-icon" data-tooltip="%s"><i class="mini-icon fa fa-sliders" aria-hidden="true"></i></a>', $row->config_id, __('Configure Additional Options'));
 		
 		if ($class) $class = 'class="' . $class . '"';
 		if (is_array($icons)) {

--- a/server/fm-modules/fmDHCP/classes/class_hosts.php
+++ b/server/fm-modules/fmDHCP/classes/class_hosts.php
@@ -82,7 +82,7 @@ class fm_dhcp_hosts extends fm_dhcp_objects {
 			$edit_status = '<td class="column-actions">' . $edit_status . '</td>';
 			$checkbox = '<input type="checkbox" name="bulk_list[]" value="' . $row->config_id .'" />';
 		}
-		$icons[] = sprintf('<a href="config-options.php?item_id=%d" class="mini-icon"><i class="mini-icon fa fa-sliders" title="%s" aria-hidden="true"></i></a>', $row->config_id, __('Configure Additional Options'));
+		$icons[] = sprintf('<a href="config-options.php?item_id=%d" class="tooltip-bottom mini-icon" data-tooltip="%s"><i class="mini-icon fa fa-sliders" aria-hidden="true"></i></a>', $row->config_id, __('Configure Additional Options'));
 		
 		if ($class) $class = 'class="' . $class . '"';
 		if (is_array($icons)) {

--- a/server/fm-modules/fmDHCP/classes/class_networks.php
+++ b/server/fm-modules/fmDHCP/classes/class_networks.php
@@ -82,7 +82,7 @@ class fm_dhcp_networks extends fm_dhcp_objects {
 			$edit_status = '<td class="column-actions">' . $edit_status . '</td>';
 			$checkbox = '<input type="checkbox" name="bulk_list[]" value="' . $row->config_id .'" />';
 		}
-		$icons[] = sprintf('<a href="config-options.php?item_id=%d" class="mini-icon"><i class="mini-icon fa fa-sliders" title="%s" aria-hidden="true"></i></a>', $row->config_id, __('Configure Additional Options'));
+		$icons[] = sprintf('<a href="config-options.php?item_id=%d" class="tooltip-bottom mini-icon" data-tooltip="%s"><i class="mini-icon fa fa-sliders" aria-hidden="true"></i></a>', $row->config_id, __('Configure Additional Options'));
 		
 		if ($class) $class = 'class="' . $class . '"';
 		if (is_array($icons)) {

--- a/server/fm-modules/fmDHCP/classes/class_objects.php
+++ b/server/fm-modules/fmDHCP/classes/class_objects.php
@@ -386,7 +386,7 @@ class fm_dhcp_objects {
 			$edit_status .= ($row->config_status == 'active') ? $__FM_CONFIG['icons']['disable'] : $__FM_CONFIG['icons']['enable'];
 			$edit_status .= '</a>';
 			$edit_status .= '<a href="#" class="delete">' . $__FM_CONFIG['icons']['delete'] . '</a>';
-			$icons[] = sprintf('<a href="config-options.php?item_id=%d" class="icons"><i class="icons fa fa-sliders" title="%s" aria-hidden="true"></i></a>', $row->config_id, __('Configure Additional Options'));
+			$icons[] = sprintf('<a href="config-options.php?item_id=%d" class="tooltip-bottom icons" data-tooltip="%s"><i class="icons fa fa-sliders" aria-hidden="true"></i></a>', $row->config_id, __('Configure Additional Options'));
 		}
 		
 		if ($class) $class = 'class="' . $class . '"';

--- a/server/fm-modules/fmDHCP/classes/class_pools.php
+++ b/server/fm-modules/fmDHCP/classes/class_pools.php
@@ -82,7 +82,7 @@ class fm_dhcp_pools extends fm_dhcp_objects {
 			$edit_status = '<td class="column-actions">' . $edit_status . '</td>';
 			$checkbox = '<input type="checkbox" name="bulk_list[]" value="' . $row->config_id .'" />';
 		}
-		$icons[] = sprintf('<a href="config-options.php?item_id=%d" class="mini-icon"><i class="mini-icon fa fa-sliders" title="%s" aria-hidden="true"></i></a>', $row->config_id, __('Configure Additional Options'));
+		$icons[] = sprintf('<a href="config-options.php?item_id=%d" class="tooltip-bottom mini-icon" data-tooltip="%s"><i class="mini-icon fa fa-sliders" aria-hidden="true"></i></a>', $row->config_id, __('Configure Additional Options'));
 		
 		if ($class) $class = 'class="' . $class . '"';
 		if (is_array($icons)) {

--- a/server/fm-modules/fmDNS/change.log
+++ b/server/fm-modules/fmDNS/change.log
@@ -1,3 +1,7 @@
+7.1.? (2025-??-??)
+==================
+* Server - [bug] Fixed inconsistent tooltips for "Configure Additional Options."
+
 7.1.2 (2025-05-01)
 ==================
 * Server - [bug] Fixed PHP errors. (Issue #680)

--- a/server/fm-modules/fmDNS/classes/class_servers.php
+++ b/server/fm-modules/fmDNS/classes/class_servers.php
@@ -489,7 +489,7 @@ class fm_module_servers extends fm_shared_module_servers {
 			$os_image = ($row->server_type == 'remote') ? '<i class="fa fa-globe fa-2x grey" style="font-size: 1.5em" title="' . __('Remote server') . '" aria-hidden="true"></i>' : setOSIcon($row->server_os_distro);
 
 			$edit_actions = $preview = ($row->server_type != 'remote') ? '<a href="preview.php" onclick="javascript:void window.open(\'preview.php?server_serial_no=' . $row->server_serial_no . '\',\'1356124444538\',\'' . $__FM_CONFIG['default']['popup']['dimensions'] . ',toolbar=0,menubar=0,location=0,status=0,scrollbars=1,resizable=1,left=0,top=0\');return false;">' . $__FM_CONFIG['icons']['preview'] . '</a>' : null;
-			if ($row->server_type != 'url-only') $icons[] = sprintf('<a href="config-options.php?server_id=%d" class="tooltip-top mini-icon" data-tooltip="%s"><i class="mini-icon fa fa-sliders" aria-hidden="true"></i></a>', $row->server_id, __('Configure Additional Options'));
+			if ($row->server_type != 'url-only') $icons[] = sprintf('<a href="config-options.php?server_id=%d" class="tooltip-bottom mini-icon" data-tooltip="%s"><i class="mini-icon fa fa-sliders" aria-hidden="true"></i></a>', $row->server_id, __('Configure Additional Options'));
 			if ($row->server_url_server_type) $icons[] = sprintf('<a href="JavaScript:void(0);" class="tooltip-top mini-icon" data-tooltip="%s"><i class="fa fa-globe" aria-hidden="true"></i></a>', sprintf(__('This server hosts URL redirects with %s for the URL RR'), $row->server_url_server_type));
 			$checkbox = null;
 

--- a/server/fm-modules/fmDNS/classes/class_templates.php
+++ b/server/fm-modules/fmDNS/classes/class_templates.php
@@ -124,7 +124,7 @@ class fm_module_templates {
 		$star = $row->$field_name == 'yes' ? str_replace(__('Super Admin'), __('Default Template'), $__FM_CONFIG['icons']['star']) : null;
 		
 		if (in_array($row->domain_type, array('primary', 'secondary')) && (currentUserCan(array('manage_zones', 'view_all'), $_SESSION['module']) || zoneAccessIsAllowed(array($row->domain_id)))) {
-			$icons[] = sprintf('<a href="config-options.php?domain_id=%d" class="tooltip-top mini-icon" data-tooltip="%s"><i class="mini-icon fa fa-sliders" aria-hidden="true"></i></a>', $row->domain_id, __('Configure Additional Options'));
+			$icons[] = sprintf('<a href="config-options.php?domain_id=%d" class="tooltip-bottom mini-icon" data-tooltip="%s"><i class="mini-icon fa fa-sliders" aria-hidden="true"></i></a>', $row->domain_id, __('Configure Additional Options'));
 		}
 
 		if (is_array($icons)) {

--- a/server/fm-modules/fmDNS/classes/class_views.php
+++ b/server/fm-modules/fmDNS/classes/class_views.php
@@ -237,7 +237,7 @@ class fm_dns_views {
 		$bars_title = __('Click and drag to reorder');
 		
 		$server_serial_no = $row->server_serial_no ? '&server_serial_no=' . $row->server_serial_no : null;
-		$icons = sprintf('<a href="config-options.php?view_id=%d%s" class="mini-icon"><i class="mini-icon fa fa-sliders" title="%s"></i></a>', $row->view_id, $server_serial_no, __('Configure Additional Options'));
+		$icons = sprintf('<a href="config-options.php?view_id=%d%s" class="tooltip-bottom mini-icon" data-tooltip="%s"><i class="mini-icon fa fa-sliders" aria-hidden="true"></i></a>', $row->view_id, $server_serial_no, __('Configure Additional Options'));
 		if (currentUserCan('manage_servers', $_SESSION['module'])) {
 			$edit_status = '<td class="column-actions">';
 			$edit_status .= '<a class="edit_form_link" href="#">' . $__FM_CONFIG['icons']['edit'] . '</a>';

--- a/server/fm-modules/fmWifi/change.log
+++ b/server/fm-modules/fmWifi/change.log
@@ -1,3 +1,7 @@
+0.7.? (2025-??-??)
+==================
+* Server - [bug] Fixed inconsistent tooltips for "Configure Additional Options."
+
 0.7.0 (2025-01-18)
 ==================
 * Server - [improvement] Made form validation global.

--- a/server/fm-modules/fmWifi/classes/class_wlans.php
+++ b/server/fm-modules/fmWifi/classes/class_wlans.php
@@ -375,7 +375,7 @@ class fm_wifi_wlans {
 			$edit_status = '<td class="column-actions">' . $edit_status . '</td>';
 			$checkbox = '<input type="checkbox" name="bulk_list[]" value="' . $row->config_id .'" />';
 		}
-		$icons[] = sprintf('<a href="config-options.php?item_id=%d" class="mini-icon"><i class="mini-icon fa fa-sliders" title="%s" aria-hidden="true"></i></a>', $row->config_id, __('Configure Additional Options'));
+		$icons[] = sprintf('<a href="config-options.php?item_id=%d" class="tooltip-bottom mini-icon" data-tooltip="%s"><i class="mini-icon fa fa-sliders" aria-hidden="true"></i></a>', $row->config_id, __('Configure Additional Options'));
 		
 		if ($class) $class = 'class="' . $class . '"';
 		if (is_array($icons)) {


### PR DESCRIPTION
Some tooltips for "Configure Additional Options" are on top. Some are on bottom. Some don't exist.

This PR puts them all on the bottom.