### PR TITLE
fM - Fix macOS detection

### DIFF
--- a/client/facileManager/functions.php
+++ b/client/facileManager/functions.php
@@ -801,14 +801,11 @@ function detectOSDistro() {
 			}
 		}
 	} elseif (PHP_OS == 'Darwin') {
-		@exec(findProgram('system_profiler') . ' SPSoftwareDataType 2>/dev/null', $output, $retval);
+		$output = passthru(findProgram('system_profiler') . ' SPSoftwareDataType 2>/dev/null | grep "System Version"', $retval);
 		if (!$retval) {
-			foreach ($output as $line) {
-				$array_line = explode(':', $line);
-				if (trim($array_line[0]) == 'System Version') {
-					$distro = trim($array_line[1]);
-					if (preg_match('/(^Mac OS)|(^OS X)/', $distro)) return 'Apple';
-				}
+			$array_line = explode(':', $output);
+			if (trim($array_line[0]) == 'System Version') {
+				if (preg_match('/(^mac\s?OS)|(^OS X)/i', trim($array_line[1]))) return 'Apple';
 			}
 		}
 	}

--- a/server/fm-modules/facileManager/change.log
+++ b/server/fm-modules/facileManager/change.log
@@ -1,3 +1,7 @@
+5.3.? (2025-??-??)
+==================
+* Client - [bug] Fix macOS detection.
+
 5.3.2 (2025-05-01)
 ==================
 * Server - [bug] Fixed PHP8.4 deprecation warnings.


### PR DESCRIPTION
Apple changed the OS labeling from OS X to Mac OS to macOS. This fix supports all three.