### PR TITLE
#718 fixes

### DIFF
--- a/server/fm-modules/facileManager/functions.php
+++ b/server/fm-modules/facileManager/functions.php
@@ -2293,6 +2293,11 @@ function makePlainText($text, $make_array = false) {
  */
 function displayTableHeader($table_info, $head_values, $tbody_id = null) {
 	if ($tbody_id) $tbody_id = ' id="' . $tbody_id . '"';
+
+	if (isset($_GET['type']) && isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$_GET['type']]['sort_direction'])) {
+		$_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']]['sort_field'] = $_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$_GET['type']]['sort_field'];
+		$_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']]['sort_direction'] = $_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$_GET['type']]['sort_direction'];
+	}
 	
 	$sort_direction = isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']]['sort_direction']) ? strtolower($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']]['sort_direction']) : 'asc';
 	
@@ -2333,32 +2338,41 @@ function displayTableHeader($table_info, $head_values, $tbody_id = null) {
 
 
 /**
- * Displays a table header
+ * Handles the sort order of table columns
  *
  * @since 1.2
  * @package facileManager
  *
- * @param array $table_info Values to build the <table> tag
- * @param array $head_values Values to build the <th> tags
- * @param string $tbody_id id for <tbody>
- * @return string
+ * @return void
  */
 function handleSortOrder() {
 	if (array_key_exists('sort_by', $_GET)) {
 		$swap_direction = array('ASC' => 'DESC', 'DESC' => 'ASC');
+		$sort_direction = 'ASC';
 
-		if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']]['sort_field']) &&
-			$_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']]['sort_field'] != $_GET['sort_by']) {
-			$sort_direction = $swap_direction[$_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']]['sort_direction']];
-		} elseif (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']]['sort_direction'])) {
-			$sort_direction = $_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']]['sort_direction'];
-		} else {
-			$sort_direction = 'ASC';
-		}
 		@session_start();
-		$_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']] = array(
-				'sort_field' => $_GET['sort_by'], 'sort_direction' => $swap_direction[$sort_direction]
-			);
+		/** Determine sort direction */
+		if (isset($_GET['type'])) {
+			if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$_GET['type']]['sort_field']) &&
+				$_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$_GET['type']]['sort_field'] != $_GET['sort_by']) {
+				$sort_direction = $swap_direction[$_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$_GET['type']]['sort_direction']];
+			} elseif (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$_GET['type']]['sort_direction'])) {
+				$sort_direction = $_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$_GET['type']]['sort_direction'];
+			}
+			$_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$_GET['type']] = array(
+					'sort_field' => $_GET['sort_by'], 'sort_direction' => $swap_direction[$sort_direction]
+				);
+		} else {
+			if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']]['sort_field']) &&
+				$_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']]['sort_field'] != $_GET['sort_by']) {
+				$sort_direction = $swap_direction[$_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']]['sort_direction']];
+			} elseif (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']]['sort_direction'])) {
+				$sort_direction = $_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']]['sort_direction'];
+			}
+			$_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']] = array(
+					'sort_field' => $_GET['sort_by'], 'sort_direction' => $swap_direction[$sort_direction]
+				);
+		}
 		session_write_close();
 	}
 	

--- a/server/fm-modules/facileManager/pages/admin-users.php
+++ b/server/fm-modules/facileManager/pages/admin-users.php
@@ -93,7 +93,9 @@ $sort_direction = null;
 $addl_title_blocks[] = buildSubMenu($type, $__FM_CONFIG['users']['avail_types']);
 echo printPageHeader($response, $display_type, $can_add, $type, null, 'noscroll', $addl_title_blocks);
 
-if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
+if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$type])) {
+	extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$type], EXTR_OVERWRITE);
+} elseif (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
 	extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']], EXTR_OVERWRITE);
 }
 

--- a/server/fm-modules/fmDHCP/pages/config-options.php
+++ b/server/fm-modules/fmDHCP/pages/config-options.php
@@ -60,7 +60,9 @@ $addl_title_blocks[] = buildObjectsSubMenu($item_id);
 
 $sort_direction = null;
 $sort_field = 'config_name';
-if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
+if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$option_type])) {
+	extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$option_type], EXTR_OVERWRITE);
+} elseif (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
 	extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']], EXTR_OVERWRITE);
 }
 

--- a/server/fm-modules/fmDNS/pages/config-controls.php
+++ b/server/fm-modules/fmDNS/pages/config-controls.php
@@ -38,7 +38,9 @@ $addl_title_blocks[] = buildServerSubMenu($server_serial_no);
 echo printPageHeader((string) $response, $display_type, currentUserCan('manage_servers', $_SESSION['module']), $type, null, 'noscroll', $addl_title_blocks);
 
 $sort_field = 'file_name';
-if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
+if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$type])) {
+	extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$type], EXTR_OVERWRITE);
+} elseif (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
 	extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']], EXTR_OVERWRITE);
 }
 

--- a/server/fm-modules/fmDNS/pages/config-dnssec.php
+++ b/server/fm-modules/fmDNS/pages/config-dnssec.php
@@ -40,7 +40,9 @@ echo printPageHeader(array('message' => (string) $response, 'comment' => getMini
 
 $sort_direction = null;
 $sort_field = 'cfg_data';
-if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
+if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$type])) {
+	extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$type], EXTR_OVERWRITE);
+} elseif (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
 	extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']], EXTR_OVERWRITE);
 }
 

--- a/server/fm-modules/fmDNS/pages/config-keys.php
+++ b/server/fm-modules/fmDNS/pages/config-keys.php
@@ -37,7 +37,9 @@ echo printPageHeader((string) $response, __('Keys') . " ($display_type)", curren
 	
 $sort_direction = null;
 $sort_field = 'key_name';
-if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
+if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$type])) {
+	extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$type], EXTR_OVERWRITE);
+} elseif (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
 	extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']], EXTR_OVERWRITE);
 }
 

--- a/server/fm-modules/fmDNS/pages/config-logging.php
+++ b/server/fm-modules/fmDNS/pages/config-logging.php
@@ -45,7 +45,9 @@ echo printPageHeader((string) $response, getPageTitle() . ' ' . $display_type, c
 	
 $sort_direction = null;
 $sort_field = 'cfg_data';
-if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
+if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$type])) {
+	extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$type], EXTR_OVERWRITE);
+} elseif (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
 	extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']], EXTR_OVERWRITE);
 }
 

--- a/server/fm-modules/fmDNS/pages/config-options.php
+++ b/server/fm-modules/fmDNS/pages/config-options.php
@@ -151,7 +151,9 @@ if ($option_type == 'rpz') {
 } else {
 	$working_class = $fm_module_options;
 
-	if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
+	if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$option_type])) {
+		extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$option_type], EXTR_OVERWRITE);
+	} elseif (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
 		extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']], EXTR_OVERWRITE);
 	}
 

--- a/server/fm-modules/fmDNS/pages/config-servers.php
+++ b/server/fm-modules/fmDNS/pages/config-servers.php
@@ -35,7 +35,9 @@ echo printPageHeader((string) $response, $display_type, currentUserCan('manage_s
 
 $sort_direction = null;
 $sort_field = null;
-if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
+if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$type])) {
+	extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$type], EXTR_OVERWRITE);
+} elseif (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
 	extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']], EXTR_OVERWRITE);
 }
 

--- a/server/fm-modules/fmWifi/pages/config-options.php
+++ b/server/fm-modules/fmWifi/pages/config-options.php
@@ -66,7 +66,9 @@ $addl_title_blocks[] = buildServerSubMenu($server_serial_no);
 
 $sort_direction = null;
 $sort_field = 'config_name';
-if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
+if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$type])) {
+	extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$type], EXTR_OVERWRITE);
+} elseif (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
 	extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']], EXTR_OVERWRITE);
 }
 

--- a/server/fm-modules/fmWifi/pages/config-servers.php
+++ b/server/fm-modules/fmWifi/pages/config-servers.php
@@ -36,7 +36,9 @@ echo printPageHeader((string) $response, $display_type, currentUserCan('manage_s
 	
 $sort_direction = null;
 $sort_field = 'server_name';
-if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
+if (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$type])) {
+	extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']][$type], EXTR_OVERWRITE);
+} elseif (isset($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']])) {
 	extract($_SESSION[$_SESSION['module']][$GLOBALS['path_parts']['filename']], EXTR_OVERWRITE);
 }
 


### PR DESCRIPTION
Fixes the table sorting for all pages utilizing a type= parameter as reported in #718. This change introduces a new array key in $_SESSION to track sorting of page types.