### PR TITLE
Allow additional status code for zone reload for action add (bux fix)

### DIFF
--- a/server/fm-modules/fmDNS/pages/api.inc.php
+++ b/server/fm-modules/fmDNS/pages/api.inc.php
@@ -394,7 +394,7 @@ switch ($method) {
 }
 
 /** Reload zone if specificed */
-if (in_array($code, [200, 201, 204]) && $zone_reload_allowed && $zone_reload_requested) {
+if (in_array($code, [200, 201, 202, 204]) && $zone_reload_allowed && $zone_reload_requested) {
     apiReloadZone($domain_id);
 }
 


### PR DESCRIPTION
If I add a record via api, the zone is not reloaded. The status code is changed from 201 to 202 in add function if we are not auto-creating a PTR record, and the 202 success code is missing in the reload conditions.